### PR TITLE
Delay unnecessary imports

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -179,7 +179,6 @@ def resource_exists(cli_ctx, resource_group, name, namespace, type, **_):  # pyl
 def register_ids_argument(cli_ctx):
 
     from knack import events
-    from msrestazure.tools import parse_resource_id, is_valid_resource_id
 
     ids_metadata = {}
 
@@ -305,6 +304,7 @@ def register_ids_argument(cli_ctx):
         if full_id_list:
             setattr(namespace, '_ids', full_id_list)
 
+        from msrestazure.tools import parse_resource_id, is_valid_resource_id
         for val in full_id_list:
             if not is_valid_resource_id(val):
                 raise CLIError('invalid resource ID: {}'.format(val))

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -16,12 +16,8 @@ import re
 import logging
 
 from six.moves.urllib.request import urlopen  # pylint: disable=import-error
-
-from azure.common import AzureException
-from azure.core.exceptions import AzureError
 from knack.log import get_logger
 from knack.util import CLIError, to_snake_case
-from inspect import getfullargspec as get_arg_spec
 
 logger = get_logger(__name__)
 
@@ -47,6 +43,8 @@ def handle_exception(ex):  # pylint: disable=too-many-return-statements
     from msrestazure.azure_exceptions import CloudError
     from msrest.exceptions import HttpOperationError, ValidationError, ClientRequestError
     from azure.cli.core.azlogging import CommandLoggerContext
+    from azure.common import AzureException
+    from azure.core.exceptions import AzureError
 
     with CommandLoggerContext(logger):
         if isinstance(ex, JMESPathTypeError):
@@ -369,6 +367,7 @@ def is_track2(client_class):
     """ IS this client a autorestv3/track2 one?.
     Could be refined later if necessary.
     """
+    from inspect import getfullargspec as get_arg_spec
     args = get_arg_spec(client_class.__init__).args
     return "credential" in args
 


### PR DESCRIPTION
## Description

Previously during CLI initialization, importing `azure.core` and `msrestazure.tools` are very time-consuming, but actually unnecessary. 

This PR delays the import until `azure.core` and `msrestazure.tools` are actually used. 

The effect is remarkable: For `az verion -h`, the import time are decreased from 1.755s to 0.648s.
 
Before: 
![image](https://user-images.githubusercontent.com/4003950/80808802-e8a9a580-8bf2-11ea-99f7-a8c003b7153e.png)

After:
![image](https://user-images.githubusercontent.com/4003950/80808837-f6f7c180-8bf2-11ea-8ddc-c97168cb0679.png)

## Testing Guide 
```
az verion -h --verbose
```

Generate the import time graph with 
```
python -X importtime -m azure.cli version -h 2>perf.log
tuna perf.log
```

