### PR TITLE
[Demo][AppService] az webapp deployment list-publishing-profiles: Return raw XML 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1872,6 +1872,8 @@ def list_publish_profiles(cmd, resource_group_name, name, slot=None):
         full_xml += f.decode()
 
     # Override the --output option provided by the user
+    # This affects how Knack retrieves the output formatter later:
+    # https://github.com/microsoft/knack/blob/0d0308bc567f2d25654bb39201c02ab262d7ce0a/knack/cli.py#L218
     cmd.cli_ctx.invocation.data['output'] = 'tsv'
     return full_xml
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1871,16 +1871,9 @@ def list_publish_profiles(cmd, resource_group_name, name, slot=None):
     for f in content:
         full_xml += f.decode()
 
-    profiles = xmltodict.parse(full_xml, xml_attribs=True)['publishData']['publishProfile']
-    converted = []
-    for profile in profiles:
-        new = {}
-        for key in profile:
-            # strip the leading '@' xmltodict put in for attributes
-            new[key.lstrip('@')] = profile[key]
-        converted.append(new)
-
-    return converted
+    # Override the --output option provided by the user
+    cmd.cli_ctx.invocation.data['output'] = 'tsv'
+    return full_xml
 
 
 def enable_cd(cmd, resource_group_name, name, enable, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1863,8 +1863,6 @@ def list_publishing_credentials(cmd, resource_group_name, name, slot=None):
 
 
 def list_publish_profiles(cmd, resource_group_name, name, slot=None):
-    import xmltodict
-
     content = _generic_site_operation(cmd.cli_ctx, resource_group_name, name,
                                       'list_publishing_profile_xml_with_secrets', slot)
     full_xml = ''


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/13777. Override the `--output` option provided by the user, so that XML is printed directly:

```
> az webapp deployment list-publishing-profiles --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/test/providers/Microsoft.Web/sites/test
<publishData><publishProfile profileName="test - Web Deploy" ...</publishData>
```

This will affect the following code in Knack:

https://github.com/microsoft/knack/blob/0d0308bc567f2d25654bb39201c02ab262d7ce0a/knack/cli.py#L218

```py
output_type = self.invocation.data['output']
if cmd_result and cmd_result.result is not None:
    formatter = self.output.get_formatter(output_type)
    self.output.out(cmd_result, formatter=formatter, out_file=out_file)
```

So that `get_formatter` will always return `format_tsv`.