### PR TITLE
Identity feature minor fixes

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -161,7 +161,10 @@ def _get_mgmt_service_client(cli_ctx,
     from azure.cli.core._profile import Profile
     logger.debug('Getting management service client client_type=%s', client_type.__name__)
     resource = resource or cli_ctx.cloud.endpoints.active_directory_resource_id
-    profile = Profile(cli_ctx=cli_ctx)
+
+    client_id = kwargs.pop('client_id', None)
+
+    profile = Profile(cli_ctx=cli_ctx, scopes=scopes, client_id=client_id)
     cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id, resource=resource,
                                                              aux_subscriptions=aux_subscriptions,
                                                              aux_tenants=aux_tenants)


### PR DESCRIPTION
 Minor fixes.

    * Only use credential cache if it is available
    * Pass tenant id to Identity properly
    * Use the client id and scopes properly in client factory
    * Accept single string scope (not a bug but good to have)