### PR TITLE
[Demo] Allow specifying a custom access token

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -436,6 +436,10 @@ def load_arguments(self, _):
                        name='resource_group_name', actions=[LocalContextAction.SET], scopes=[ALL]))
         c.argument('managed_by', min_api='2016-09-01', help='The ID of the resource that manages this resource group.')
 
+    with self.argument_context('group show') as c:
+        c.argument('rg_name', options_list=['--name', '--resource-group', '-n', '-g'],
+                   help='name of the resource group', completer=None)
+
     with self.argument_context('group delete') as c:
         c.argument('resource_group_name', resource_group_name_type,
                    options_list=['--name', '-n', '--resource-group', '-g'], local_context_attribute=None)

--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -168,7 +168,7 @@ def load_command_table(self, _):
 
     with self.command_group('group', resource_group_sdk, resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
         g.command('delete', 'delete', supports_no_wait=True, confirmation=True)
-        g.show_command('show', 'get')
+        g.custom_show_command('show', 'get_resource_group')
         g.command('exists', 'check_existence')
         g.custom_command('list', 'list_resource_groups', table_transformer=transform_resource_group_list)
         g.custom_command('create', 'create_resource_group')

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1148,18 +1148,22 @@ def create_resource_group(cmd, rg_name, location, tags=None, managed_by=None):
     return rcf.resource_groups.create_or_update(rg_name, parameters)
 
 
-def get_resource_group(cmd, rg_name, access_token):
-    from unittest import mock
-    # patch get_login_credentials so that the client created by
-    # azure.cli.core.commands.client_factory.get_mgmt_service_client uses our own credential
-    with mock.patch("azure.cli.core._profile.Profile.get_login_credentials") as mock_get_login_credentials:
-        # We use BasicTokenAuthentication to replace azure.cli.core.adal_authentication.AdalAuthentication
-        from msrest.authentication import BasicTokenAuthentication
-        cred = BasicTokenAuthentication({"access_token": access_token})
-        # Return a tuple of (credential, subscription_id, tenant_id(unused))
-        mock_get_login_credentials.return_value = cred, cmd.cli_ctx.data['subscription_id'], None
+def get_resource_group(cmd, rg_name, access_token=None):
+    if access_token:
+        logger.warning("Using the provided access token.")
+        from unittest import mock
+        # patch get_login_credentials so that the client created by
+        # azure.cli.core.commands.client_factory.get_mgmt_service_client uses our own credential
+        with mock.patch("azure.cli.core._profile.Profile.get_login_credentials") as mock_get_login_credentials:
+            # We use BasicTokenAuthentication to replace azure.cli.core.adal_authentication.AdalAuthentication
+            from msrest.authentication import BasicTokenAuthentication
+            cred = BasicTokenAuthentication({"access_token": access_token})
+            # Return a tuple of (credential, subscription_id, tenant_id(unused))
+            mock_get_login_credentials.return_value = cred, cmd.cli_ctx.data['subscription_id'], None
+            client = _resource_client_factory(cmd.cli_ctx)
+    else:
+        logger.warning("Using the credential from `az login`.")
         client = _resource_client_factory(cmd.cli_ctx)
-
     return client.resource_groups.get(rg_name)
 
 


### PR DESCRIPTION
**Description<!--Mandatory-->**  

Allow specifying a custom access token by monkey-patching `azure.cli.core._profile.Profile.get_login_credentials`.

**Testing Guide**  

```powershell
# With --access-token
> az group show -n fy --subscription 0b1f6471-1bf0-4dda-aec3-cb9272f09590 --access-token "eyJ0eXAiO..."
Subscription '0b1f6471-1bf0-4dda-aec3-cb9272f09590' not recognized.
Using the provided access token.
{
  "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/fy",
  "location": "westus",
  "managedBy": null,
  "name": "fy",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": null,
  "type": "Microsoft.Resources/resourceGroups"
}

# Without --access-token
> az group show -n fy
Using the credential from `az login`.
{
  "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/fy",
  "location": "westus",
  "managedBy": null,
  "name": "fy",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": null,
  "type": "Microsoft.Resources/resourceGroups"
}
```

Note that this warning 

> Subscription '0b1f6471-1bf0-4dda-aec3-cb9272f09590' not recognized.

can't be disabled by monkey-patching because it is printed before the command reaches `get_resource_group`. To hide it, use [`--only-show-errors`](https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration?view=azure-cli-latest#cli-configuration-values-and-environment-variables).
