### PR TITLE
[PoC] Allow specifying a custom access token - Track 2 approach

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -177,3 +177,16 @@ def read_response_templates():
         error_template = f.read()
 
     return success_template, error_template
+
+
+class AccessTokenCredential:
+    """Simple access token Authentication. Returns the access token as-is.
+    """
+
+    def __init__(self, access_token):
+        self.access_token = access_token
+
+    def get_token(self, *arg, **kwargs):
+        import time
+        # Assume the access token expires in 1 year
+        return AccessToken(self.access_token, int(time.time()) + 31536000)

--- a/src/azure-cli/azure/cli/command_modules/resource/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_client_factory.py
@@ -4,10 +4,10 @@
 # --------------------------------------------------------------------------------------------
 
 
-def _resource_client_factory(cli_ctx, **_):
+def _resource_client_factory(cli_ctx, **kwargs):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from azure.cli.core.profiles import ResourceType
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES, **kwargs)
 
 
 def _resource_feature_client_factory(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1270,11 +1270,16 @@ def _validate_resource_inputs(resource_group_name, resource_provider_namespace,
 
 # region Custom Commands
 
-def list_resource_groups(cmd, tag=None):  # pylint: disable=no-self-use
+def list_resource_groups(cmd, tag=None, access_token=None):  # pylint: disable=no-self-use
     """ List resource groups, optionally filtered by a tag.
     :param str tag:tag to filter by in 'key[=value]' format
     """
-    rcf = _resource_client_factory(cmd.cli_ctx)
+    cred = None
+    if access_token:
+        # Use custom access token
+        from azure.cli.core.auth.util import AccessTokenCredential
+        cred = AccessTokenCredential(access_token=access_token)
+    rcf = _resource_client_factory(cmd.cli_ctx, credential=cred, subscription_id=cmd.cli_ctx.data['subscription_id'])
 
     filters = []
     if tag:


### PR DESCRIPTION
A rework of https://github.com/jiasli/azure-cli/pull/12:

- Remove the usage of `msrest.authentication.BasicTokenAuthentication`
- Use Track 2 SDK `get_token` protocol

Instead of monkey-patching `get_login_credentials`, we make `_get_mgmt_service_client` support **custom credential** natively.

But if we implement `EnvironmentCredential` (https://github.com/Azure/azure-cli/issues/10241), custom credential support may not be necessary since we can combine the logic into `EnvironmentCredential`.